### PR TITLE
Updated graphql.js dependency to 0.7.0 so there will be no duplicates

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "es6-promise": "^3.2.1",
-    "graphql": "^0.6.2",
+    "graphql": "^0.7.0",
     "graphql-subscriptions": "^0.1.3",
     "lodash": "^4.15.0",
     "node-static": "0.5.9",
@@ -42,7 +42,7 @@
     "mocha": "^3.0.0",
     "remap-istanbul": "^0.6.4",
     "tslint": "^3.13.0",
-    "typescript": "^1.8.10",
+    "typescript": "^2.0.0",
     "typings": "^1.3.2"
   },
   "typings": "dist/index.d.ts",


### PR DESCRIPTION
Following on this PR https://github.com/apollostack/graphql-subscriptions/pull/4

Also:
* Updated typescript to version ^2.0.0 to allow for trailing commas on function parameters (wasn't allowed on older versions)

