### PR TITLE
Fix typo in client-side SUBSCRIPTION_FAIL handling

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -72,7 +72,7 @@ export default class Client {
           break;
         case SUBSCRIPTION_FAIL:
           if (this.subscriptionHandlers[subId]) {
-            this.subscriptionHandlers[subId](parsedMessage.errors, null);
+            this.subscriptionHandlers[subId](parsedMessage.payload.errors, null);
           }
           delete this.subscriptionHandlers[subId];
           delete this.waitingSubscriptions[subId];

--- a/src/test/tests.ts
+++ b/src/test/tests.ts
@@ -201,6 +201,28 @@ describe('Client', function() {
     }, 200);
   });
 
+  it('should call error handler when graphql query is not valid', function(done) {
+    const client = new Client(`ws://localhost:${TEST_PORT}/`);
+
+    setTimeout( () => {
+    client.subscribe({
+        query:
+        `subscription useInfo{
+          invalid
+        }`,
+        variables: {},
+      }, function(error, result) {
+          if (error) {
+            expect(error[0].message).to.equals('Cannot query field "invalid" on type "Subscription".');
+            done();
+          } else {
+            assert(false);
+          }
+        }
+      );
+    }, 100);
+  });
+
   it('should throw an error when the susbcription times out', function(done) {
     // hopefully 1ms is fast enough to time out before the server responds
     const client = new Client(`ws://localhost:${TEST_PORT}/`, { timeout: 1 });


### PR DESCRIPTION
Without this fix, if there are errors on the server side, the client will still run the `next(..)` handler on the client, instead of the `error(..)` handler.

This seems like a simple oversight, since the next block uses `payload.errors` correctly.