### PR TITLE
Use specific lodash functions instead of package

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   "dependencies": {
     "es6-promise": "^3.2.1",
     "graphql-subscriptions": "^0.1.3",
-    "lodash": "^4.15.0",
+    "lodash.isobject": "^3.0.2",
+    "lodash.isstring": "^4.0.1",
     "node-static": "0.5.9",
     "websocket": "^1.0.23"
   },

--- a/src/client.ts
+++ b/src/client.ts
@@ -9,10 +9,8 @@ import {
   SUBSCRIPTION_END,
 } from './messageTypes';
 
-import {
-  isString,
-  isObject,
-} from 'lodash';
+import isString = require('lodash.isstring');
+import isObject = require('lodash.isobject');
 
 export interface SubscriptionOptions {
   query: string;

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -1,1 +1,11 @@
 /// <reference types="typed-graphql" />
+
+declare module 'lodash.isobject' {
+  import main = require('lodash');
+  export = main.isObject;
+}
+
+declare module 'lodash.isstring' {
+  import main = require('lodash');
+  export = main.isString;
+}

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -1,11 +1,11 @@
 /// <reference types="typed-graphql" />
 
 declare module 'lodash.isobject' {
-  import main = require('lodash');
-  export = main.isObject;
+  import {isObject} from 'lodash';
+  export = isObject;
 }
 
 declare module 'lodash.isstring' {
-  import main = require('lodash');
-  export = main.isString;
+  import {isString} from 'lodash';
+  export = isString;
 }


### PR DESCRIPTION
Importing the complete lodash package is:

- heavy, we only need two functions here!
- side effects by changing the _ in the global scope (for example, someone using underscore in a legacy backbone app will be affected ;) )