### PR TITLE
Keep alive socket

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -7,6 +7,7 @@ import {
   SUBSCRIPTION_START,
   SUBSCRIPTION_SUCCESS,
   SUBSCRIPTION_END,
+  SUBSCRIPTION_KEEPALIVE,
 } from './messageTypes';
 import { GRAPHQL_SUBSCRIPTIONS } from './protocols';
 
@@ -84,8 +85,11 @@ export default class Client {
           }
           break;
 
+        case SUBSCRIPTION_KEEPALIVE:
+          break;
+
         default:
-          throw new Error('Invalid message type - must be of type `subscription_start` or `subscription_data`.');
+          throw new Error('Invalid message type - must be of type `subscription_start`, `subscription_data` or `subscription_keepalive`.');
       }
 
     };

--- a/src/client.ts
+++ b/src/client.ts
@@ -57,7 +57,7 @@ export default class Client {
         throw new Error('Message must be JSON-parseable.');
       }
       const subId = parsedMessage.id;
-      if (!this.subscriptionHandlers[subId]) {
+      if (parsedMessage.type !== SUBSCRIPTION_KEEPALIVE && !this.subscriptionHandlers[subId]) {
         this.unsubscribe(subId);
         return;
       }

--- a/src/messageTypes.ts
+++ b/src/messageTypes.ts
@@ -3,10 +3,12 @@ const SUBSCRIPTION_END = 'subscription_end';
 const SUBSCRIPTION_DATA = 'subscription_data';
 const SUBSCRIPTION_START = 'subscription_start';
 const SUBSCRIPTION_SUCCESS = 'subscription_success';
+const SUBSCRIPTION_KEEPALIVE = 'subscription_keepalive';
 export {
     SUBSCRIPTION_DATA,
     SUBSCRIPTION_END,
     SUBSCRIPTION_FAIL,
     SUBSCRIPTION_START,
     SUBSCRIPTION_SUCCESS,
+    SUBSCRIPTION_KEEPALIVE,
 };


### PR DESCRIPTION
Some PAAS such as heroku limit the time a socket can stay open without sending anything. By adding the `keepAlive` option in the server's settings, you can now make sure the socket will stay open by sending empty keep alive packets in it from time to time.

`keepAlive` takes an amount of milliseconds as parameter and will yield an empty keep alive message each time this interval goes off.