### PR TITLE
Prevent server crashes with incorrect clients

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -172,7 +172,9 @@ class Server {
           break;
 
         default:
-          throw new Error('Invalid message type. Message type must be `subscription_start` or `subscription_end`.');
+          this.sendSubscriptionFail(connection, subId, {
+            errors: ['Invalid message type. Message type must be `subscription_start` or `subscription_end`.']
+          });
       }
     };
   }

--- a/src/server.ts
+++ b/src/server.ts
@@ -116,12 +116,8 @@ class Server {
       try {
         parsedMessage = JSON.parse(message.utf8Data);
       } catch (e) {
-        let failMessage = {
-          type: SUBSCRIPTION_FAIL,
-          errors: ['Message must be JSON-parseable.'],
-          id: parsedMessage.id,
-        };
-        connection.sendUTF(JSON.stringify(failMessage));
+        this.sendSubscriptionFail(connection, null, { errors: [e.message] });
+        return;
       }
 
       const subId = parsedMessage.id;

--- a/src/test/tests.ts
+++ b/src/test/tests.ts
@@ -511,6 +511,20 @@ describe('Server', function() {
     };
   });
 
+  it('rejects unparsable message', function(done) {
+    const client = new W3CWebSocket(`ws://localhost:${TEST_PORT}/`, GRAPHQL_SUBSCRIPTIONS);
+    client.onmessage = (message: any) => {
+      let messageData = JSON.parse(message.data);
+      assert.equal(messageData.type, SUBSCRIPTION_FAIL);
+      assert.isAbove(messageData.payload.errors.length, 0, 'Number of errors is greater than 0.');
+      client.close();
+      done();
+    };
+    client.onopen = () => {
+      client.send('HI');
+    };
+  });
+
   it('sends a keep alive signal in the socket', function(done) {
     let client = new W3CWebSocket(`ws://localhost:${TEST_PORT + 1}/`, GRAPHQL_SUBSCRIPTIONS);
     let yieldCount = 0;

--- a/src/test/tests.ts
+++ b/src/test/tests.ts
@@ -525,6 +525,20 @@ describe('Server', function() {
     };
   });
 
+  it('rejects nonsense message', function(done) {
+    const client = new W3CWebSocket(`ws://localhost:${TEST_PORT}/`, GRAPHQL_SUBSCRIPTIONS);
+    client.onmessage = (message: any) => {
+      let messageData = JSON.parse(message.data);
+      assert.equal(messageData.type, SUBSCRIPTION_FAIL);
+      assert.isAbove(messageData.payload.errors.length, 0, 'Number of errors is greater than 0.');
+      client.close();
+      done();
+    };
+    client.onopen = () => {
+      client.send(JSON.stringify({}));
+    };
+  });
+
   it('sends a keep alive signal in the socket', function(done) {
     let client = new W3CWebSocket(`ws://localhost:${TEST_PORT + 1}/`, GRAPHQL_SUBSCRIPTIONS);
     let yieldCount = 0;


### PR DESCRIPTION
These two commits cover a couple more cases where a client sending invalid messages was crashing the server.