### PR TITLE
improve error handling in server and client

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -168,9 +168,12 @@ export default class Client {
   }
 
   // ensure we have an array of errors
-  private formatErrors(errors: Array<any>) {
+  private formatErrors(errors: any) {
     if (Array.isArray(errors)) {
       return errors;
+    }
+    if (errors && errors.message) {
+      return [errors];
     }
     return [{ message: 'Unknown error' }];
   }

--- a/src/client.ts
+++ b/src/client.ts
@@ -71,7 +71,7 @@ export default class Client {
           break;
         case SUBSCRIPTION_FAIL:
           if (this.subscriptionHandlers[subId]) {
-            this.subscriptionHandlers[subId](parsedMessage.payload.errors, null);
+            this.subscriptionHandlers[subId](this.formatErrors(parsedMessage.payload.errors), null);
           }
           delete this.subscriptionHandlers[subId];
           delete this.waitingSubscriptions[subId];
@@ -81,7 +81,7 @@ export default class Client {
           if (parsedMessage.payload.data && !parsedMessage.payload.errors) {
               this.subscriptionHandlers[subId](null, parsedMessage.payload.data);
           } else {
-            this.subscriptionHandlers[subId](parsedMessage.payload.errors, null);
+            this.subscriptionHandlers[subId](this.formatErrors(parsedMessage.payload.errors), null);
           }
           break;
 
@@ -167,4 +167,11 @@ export default class Client {
     return id;
   }
 
+  // ensure we have an array of errors
+  private formatErrors(errors: Array<any>) {
+    if (Array.isArray(errors)) {
+      return errors;
+    }
+    return [{ message: 'Unknown error' }];
+  }
 };

--- a/src/server.ts
+++ b/src/server.ts
@@ -116,7 +116,7 @@ class Server {
       try {
         parsedMessage = JSON.parse(message.utf8Data);
       } catch (e) {
-        this.sendSubscriptionFail(connection, null, { errors: [e.message] });
+        this.sendSubscriptionFail(connection, null, { errors: [{ message: e.message }] });
         return;
       }
 
@@ -157,7 +157,11 @@ class Server {
             connectionSubscriptions[subId] = graphqlSubId;
             this.sendSubscriptionSuccess(connection, subId);
           }).catch( e => {
-            this.sendSubscriptionFail(connection, subId, { errors: e.errors });
+            if (e.errors) {
+              this.sendSubscriptionFail(connection, subId, { errors: e.errors });
+            } else {
+              this.sendSubscriptionFail(connection, subId, { errors: [{ message: e.message }] });
+            }
             return;
           });
           break;
@@ -173,7 +177,9 @@ class Server {
 
         default:
           this.sendSubscriptionFail(connection, subId, {
-            errors: ['Invalid message type. Message type must be `subscription_start` or `subscription_end`.']
+            errors: [{
+              message: 'Invalid message type. Message type must be `subscription_start` or `subscription_end`.'
+            }]
           });
       }
     };

--- a/src/test/tests.ts
+++ b/src/test/tests.ts
@@ -539,6 +539,21 @@ describe('Server', function() {
     };
   });
 
+  it('sends back any type of error', function(done) {
+    const client = new Client(`ws://localhost:${TEST_PORT}/`);
+    client.subscribe({
+      query:
+        `invalid useInfo{
+          error
+        }`,
+      variables: {},
+    }, function(errors, result) {
+      client.unsubscribeAll();
+      assert.isAbove(errors.length, 0, 'Number of errors is greater than 0.');
+      done();
+    });
+  });
+
   it('sends a keep alive signal in the socket', function(done) {
     let client = new W3CWebSocket(`ws://localhost:${TEST_PORT + 1}/`, GRAPHQL_SUBSCRIPTIONS);
     let yieldCount = 0;


### PR DESCRIPTION
I noticed that is the `subscriptionManager.subscribe` threw a regular Error object the client received `undefined` despite the message type being `SUBSCRIPTION_FAIL` hence the introduction of `formatErrors`. The server was updated to check for `e.errors` and otherwise create a formatted error object.