### PR TITLE
Don't let transport to fail silently

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -157,7 +157,7 @@ class Server {
             connectionSubscriptions[subId] = graphqlSubId;
             this.sendSubscriptionSuccess(connection, subId);
           }).catch( e => {
-            this.sendSubscriptionFail(connection, subId, { errors: e.errors });
+            this.sendSubscriptionFail(connection, subId, { errors: e.errors || e.message });
             return;
           });
           break;


### PR DESCRIPTION
Don't let transport to fail silently on general exceptions. Send error message to client instead.