### PR TITLE
Client reconnection logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "url": "git+https://github.com/apollostack/subscriptions-transport-ws.git"
   },
   "dependencies": {
+    "@types/node": "^6.0.38",
     "backo2": "^1.0.2",
     "es6-promise": "^3.2.1",
     "graphql-subscriptions": "^0.1.3",
@@ -31,7 +32,6 @@
     "@types/chai": "^3.4.32",
     "@types/lodash": "^4.14.34",
     "@types/mocha": "^2.2.31",
-    "@types/node": "^6.0.38",
     "@types/sinon": "^1.16.31",
     "@types/websocket": "0.0.30",
     "babel-cli": "^6.11.4",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "git+https://github.com/apollostack/subscriptions-transport-ws.git"
   },
   "dependencies": {
-    "@types/node": "^6.0.38",
+    "backo2": "^1.0.2",
     "es6-promise": "^3.2.1",
     "graphql-subscriptions": "^0.1.3",
     "lodash.isobject": "^3.0.2",
@@ -31,6 +31,7 @@
     "@types/chai": "^3.4.32",
     "@types/lodash": "^4.14.34",
     "@types/mocha": "^2.2.31",
+    "@types/node": "^6.0.38",
     "@types/sinon": "^1.16.31",
     "@types/websocket": "0.0.30",
     "babel-cli": "^6.11.4",

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,5 +1,6 @@
 import * as websocket from 'websocket';
 const W3CWebSocket = (websocket as { [key: string]: any })['w3cwebsocket'];
+import * as Backoff from 'backo2';
 
 import {
   SUBSCRIPTION_FAIL,
@@ -21,78 +22,57 @@ export interface SubscriptionOptions {
   context?: any;
 }
 
+export interface Subscription {
+  options: SubscriptionOptions,
+  handler: (error: Error[], result?: any) => void,
+}
+
+export interface Subscriptions {
+  [id: string]: Subscription;
+}
+
+export interface ClientOptions {
+  timeout?: number;
+  reconnect?: boolean;
+  reconnectionAttempts?: number;
+}
+
 const DEFAULT_SUBSCRIPTION_TIMEOUT = 5000;
 
 export default class Client {
 
   public client: any;
-  public subscriptionHandlers: {[id: string]: (error: Error[], result?: any) => void};
+  public subscriptions: Subscriptions;
+  private url: string;
   private maxId: number;
   private subscriptionTimeout: number;
   private waitingSubscriptions: {[id: string]: boolean}; // subscriptions waiting for SUBSCRIPTION_SUCCESS
   private unsentMessagesQueue: Array<any>; // queued messages while websocket is opening.
+  private reconnect: boolean;
+  private reconnecting: boolean;
+  private reconnectionAttempts: number;
+  private reconnectSubscriptions: Subscriptions;
+  private backoff: any;
 
-  constructor(url: string, options?: { timeout: number }) {
+  constructor(url: string, options?: ClientOptions) {
+    const {
+      timeout = DEFAULT_SUBSCRIPTION_TIMEOUT,
+      reconnect = false,
+      reconnectionAttempts = Infinity,
+    } = (options || {});
 
-    this.client = new W3CWebSocket(url, GRAPHQL_SUBSCRIPTIONS);
-    this.subscriptionHandlers = {}; // id: handler
+    this.url = url;
+    this.subscriptions = {};
     this.maxId = 0;
-    this.subscriptionTimeout = (options && options.timeout) || DEFAULT_SUBSCRIPTION_TIMEOUT;
+    this.subscriptionTimeout = timeout;
     this.waitingSubscriptions = {};
-
     this.unsentMessagesQueue = [];
-
-    this.client.onopen = () => {
-      this.unsentMessagesQueue.forEach((message) => {
-          this.client.send(JSON.stringify(message));
-      });
-      this.unsentMessagesQueue = [];
-    }
-
-    this.client.onmessage = (message: { data: string }) => {
-      let parsedMessage: any;
-      try {
-        parsedMessage = JSON.parse(message.data);
-      } catch (e) {
-        throw new Error('Message must be JSON-parseable.');
-      }
-      const subId = parsedMessage.id;
-      if (parsedMessage.type !== SUBSCRIPTION_KEEPALIVE && !this.subscriptionHandlers[subId]) {
-        this.unsubscribe(subId);
-        return;
-      }
-
-      // console.log('MSG', JSON.stringify(parsedMessage, null, 2));
-      switch (parsedMessage.type) {
-
-        case SUBSCRIPTION_SUCCESS:
-          delete this.waitingSubscriptions[subId];
-
-          break;
-        case SUBSCRIPTION_FAIL:
-          if (this.subscriptionHandlers[subId]) {
-            this.subscriptionHandlers[subId](this.formatErrors(parsedMessage.payload.errors), null);
-          }
-          delete this.subscriptionHandlers[subId];
-          delete this.waitingSubscriptions[subId];
-
-          break;
-        case SUBSCRIPTION_DATA:
-          if (parsedMessage.payload.data && !parsedMessage.payload.errors) {
-              this.subscriptionHandlers[subId](null, parsedMessage.payload.data);
-          } else {
-            this.subscriptionHandlers[subId](this.formatErrors(parsedMessage.payload.errors), null);
-          }
-          break;
-
-        case SUBSCRIPTION_KEEPALIVE:
-          break;
-
-        default:
-          throw new Error('Invalid message type - must be of type `subscription_start`, `subscription_data` or `subscription_keepalive`.');
-      }
-
-    };
+    this.reconnect = reconnect;
+    this.reconnectSubscriptions = {};
+    this.reconnecting = false;
+    this.reconnectionAttempts = reconnectionAttempts;
+    this.backoff = new Backoff({ jitter: 0.5 });
+    this.connect();
   }
 
   public subscribe(options: SubscriptionOptions, handler: (error: Error[], result?: any) => void) {
@@ -115,28 +95,29 @@ export default class Client {
       '`operationName` must be a string, and `variables` must be an object.');
     }
 
-      const subId = this.generateSubscriptionId();
-      let message = Object.assign(options, {type: SUBSCRIPTION_START, id: subId});
-      this.sendMessage(message);
-      this.subscriptionHandlers[subId] = handler;
-      this.waitingSubscriptions[subId] = true;
-      setTimeout( () => {
-        if (this.waitingSubscriptions[subId]){
-          handler([new Error('Subscription timed out - no response from server')]);
-          this.unsubscribe(subId);
-        }
-      }, this.subscriptionTimeout);
-      return subId;
+    const subId = this.generateSubscriptionId();
+    let message = Object.assign(options, {type: SUBSCRIPTION_START, id: subId});
+    this.sendMessage(message);
+    this.subscriptions[subId] = {options, handler};
+    this.waitingSubscriptions[subId] = true;
+    setTimeout( () => {
+      if (this.waitingSubscriptions[subId]){
+        handler([new Error('Subscription timed out - no response from server')]);
+        this.unsubscribe(subId);
+      }
+    }, this.subscriptionTimeout);
+    return subId;
   }
 
   public unsubscribe(id: number) {
-    delete this.subscriptionHandlers[id];
+    delete this.subscriptions[id];
+    delete this.waitingSubscriptions[id];
     let message = { id: id, type: SUBSCRIPTION_END};
     this.sendMessage(message);
   }
 
   public unsubscribeAll() {
-    Object.keys(this.subscriptionHandlers).forEach( subId => {
+    Object.keys(this.subscriptions).forEach( subId => {
       this.unsubscribe(parseInt(subId));
     });
   }
@@ -157,7 +138,9 @@ export default class Client {
       case this.client.CLOSING:
       case this.client.CLOSED:
       default:
-        throw new Error('Client is not connected to a websocket.');
+        if (!this.reconnecting) {
+          throw new Error('Client is not connected to a websocket.');
+        }
     }
   }
 
@@ -176,5 +159,87 @@ export default class Client {
       return [errors];
     }
     return [{ message: 'Unknown error' }];
+  }
+
+  private tryReconnect() {
+    if (!this.reconnect) {
+      return;
+    }
+    if (this.backoff.attempts > this.reconnectionAttempts) {
+      return;
+    }
+    if (!this.reconnecting) {
+      this.reconnectSubscriptions = this.subscriptions;
+      this.subscriptions = {};
+      this.waitingSubscriptions = {};
+      this.reconnecting = true;
+    }
+    const delay = this.backoff.duration();
+    setTimeout(() => {
+      this.connect();
+    }, delay);
+  }
+
+  private connect() {
+    this.client = new W3CWebSocket(this.url, GRAPHQL_SUBSCRIPTIONS);
+
+    this.client.onopen = () => {
+      this.reconnecting = false;
+      this.backoff.reset();
+      Object.keys(this.reconnectSubscriptions).forEach((key) => {
+        const { options, handler } = this.reconnectSubscriptions[key];
+        this.subscribe(options, handler);
+      })
+      this.unsentMessagesQueue.forEach((message) => {
+        this.client.send(JSON.stringify(message));
+      });
+      this.unsentMessagesQueue = [];
+    };
+
+    this.client.onclose = () => {
+      this.tryReconnect();
+    };
+
+    this.client.onmessage = (message: { data: string }) => {
+      let parsedMessage: any;
+      try {
+        parsedMessage = JSON.parse(message.data);
+      } catch (e) {
+        throw new Error('Message must be JSON-parseable.');
+      }
+      const subId = parsedMessage.id;
+      if (parsedMessage.type !== SUBSCRIPTION_KEEPALIVE && !this.subscriptions[subId]) {
+        this.unsubscribe(subId);
+        return;
+      }
+
+      // console.log('MSG', JSON.stringify(parsedMessage, null, 2));
+      switch (parsedMessage.type) {
+
+        case SUBSCRIPTION_SUCCESS:
+          delete this.waitingSubscriptions[subId];
+
+          break;
+        case SUBSCRIPTION_FAIL:
+          this.subscriptions[subId].handler(this.formatErrors(parsedMessage.payload.errors), null);
+          delete this.subscriptions[subId];
+          delete this.waitingSubscriptions[subId];
+
+          break;
+        case SUBSCRIPTION_DATA:
+          if (parsedMessage.payload.data && !parsedMessage.payload.errors) {
+              this.subscriptions[subId].handler(null, parsedMessage.payload.data);
+          } else {
+            this.subscriptions[subId].handler(this.formatErrors(parsedMessage.payload.errors), null);
+          }
+          break;
+
+        case SUBSCRIPTION_KEEPALIVE:
+          break;
+
+        default:
+          throw new Error('Invalid message type - must be of type `subscription_start`, `subscription_data` or `subscription_keepalive`.');
+      }
+    };
   }
 };

--- a/src/client.ts
+++ b/src/client.ts
@@ -71,7 +71,7 @@ export default class Client {
           break;
         case SUBSCRIPTION_FAIL:
           if (this.subscriptionHandlers[subId]) {
-            this.subscriptionHandlers[subId](parsedMessage.payload.errors, null);
+            this.subscriptionHandlers[subId](this.formatErrors(parsedMessage.payload.errors), null);
           }
           delete this.subscriptionHandlers[subId];
           delete this.waitingSubscriptions[subId];
@@ -81,7 +81,7 @@ export default class Client {
           if (parsedMessage.payload.data && !parsedMessage.payload.errors) {
               this.subscriptionHandlers[subId](null, parsedMessage.payload.data);
           } else {
-            this.subscriptionHandlers[subId](parsedMessage.payload.errors, null);
+            this.subscriptionHandlers[subId](this.formatErrors(parsedMessage.payload.errors), null);
           }
           break;
 
@@ -167,4 +167,11 @@ export default class Client {
     return id;
   }
 
+  // ensure we have an array of errors
+  private formatErrors(errors: Array<any>) {
+    if (Array.isArray(errors)) {
+      return errors;
+    }
+    return [{ message: 'Unknown error' }];
+  }
 };

--- a/src/server.ts
+++ b/src/server.ts
@@ -116,7 +116,7 @@ class Server {
       try {
         parsedMessage = JSON.parse(message.utf8Data);
       } catch (e) {
-        this.sendSubscriptionFail(connection, null, { errors: [e.message] });
+        this.sendSubscriptionFail(connection, null, { errors: [{ message: e.message }] });
         return;
       }
 
@@ -157,7 +157,11 @@ class Server {
             connectionSubscriptions[subId] = graphqlSubId;
             this.sendSubscriptionSuccess(connection, subId);
           }).catch( e => {
-            this.sendSubscriptionFail(connection, subId, { errors: e.errors });
+            if (e.errors) {
+              this.sendSubscriptionFail(connection, subId, { errors: e.errors });
+            } else {
+              this.sendSubscriptionFail(connection, subId, { errors: [{ message: e.message }] });
+            }
             return;
           });
           break;
@@ -173,7 +177,9 @@ class Server {
 
         default:
           this.sendSubscriptionFail(connection, subId, {
-            errors: ['Invalid message type. Message type must be `subscription_start` or `subscription_end`.']
+            errors: [{
+              message: 'Invalid message type. Message type must be `subscription_start` or `subscription_end`.'
+            }]
           });
       }
     };

--- a/src/test/tests.ts
+++ b/src/test/tests.ts
@@ -539,6 +539,21 @@ describe('Server', function() {
     };
   });
 
+  it('sends back any type of error', function(done) {
+    const client = new Client(`ws://localhost:${TEST_PORT}/`);
+    client.subscribe({
+      query:
+        `invalid useInfo{
+          error
+        }`,
+      variables: {},
+    }, function(errors, result) {
+      client.unsubscribeAll();
+      assert.isAbove(errors.length, 0, 'Number of errors is greater than 0.');
+      done();
+    });
+  });
+
   it('sends a keep alive signal in the socket', function(done) {
     let client = new W3CWebSocket(`ws://localhost:${TEST_PORT + 1}/`, GRAPHQL_SUBSCRIPTIONS);
     let yieldCount = 0;

--- a/src/test/tests.ts
+++ b/src/test/tests.ts
@@ -22,7 +22,7 @@ import {
   GRAPHQL_SUBSCRIPTIONS,
 } from '../protocols';
 
-import { createServer } from 'http';
+import { createServer, IncomingMessage, ServerResponse } from 'http';
 import SubscriptionServer from '../server';
 import Client from '../client';
 
@@ -33,6 +33,8 @@ import * as websocket from 'websocket';
 const W3CWebSocket = (websocket as { [key: string]: any })['w3cwebsocket'];
 
 const TEST_PORT = 4953;
+const KEEP_ALIVE_TEST_PORT = TEST_PORT + 1;
+const DELAYED_TEST_PORT = TEST_PORT + 2;
 
 const data: { [key: string]: { [key: string]: string } } = {
   '1': {
@@ -116,27 +118,34 @@ const subscriptionManager = new SubscriptionManager({
 const options = {
   subscriptionManager,
   onSubscribe: (msg: SubscribeMessage, params: SubscriptionOptions) => {
-      return Promise.resolve(Object.assign({}, params, { context: msg['context'] }));
+    return Promise.resolve(Object.assign({}, params, { context: msg['context'] }));
   },
 };
 
-const httpServer = createServer(function(request, response) {
-    response.writeHead(404);
-    response.end();
-  });
+function notFoundRequestListener(request: IncomingMessage, response: ServerResponse) {
+  response.writeHead(404);
+  response.end();
+}
 
-httpServer.listen(TEST_PORT, function() {
-  // console.log(`Server is listening on port ${TEST_PORT}`);
-});
+const httpServer = createServer(notFoundRequestListener);
+httpServer.listen(TEST_PORT);
 new SubscriptionServer(options, httpServer);
 
-const httpServerWithKA = createServer(function(request, response) {
-    response.writeHead(404);
-    response.end();
-  });
-
-httpServerWithKA.listen(TEST_PORT + 1);
+const httpServerWithKA = createServer(notFoundRequestListener);
+httpServerWithKA.listen(KEEP_ALIVE_TEST_PORT);
 new SubscriptionServer(Object.assign({}, options, {keepAlive: 10}), httpServerWithKA);
+
+const httpServerWithDelay = createServer(notFoundRequestListener);
+httpServerWithDelay.listen(DELAYED_TEST_PORT);
+new SubscriptionServer(Object.assign({}, options, {
+  onSubscribe: (msg: SubscribeMessage, params: SubscriptionOptions) => {
+    return new Promise((resolve, reject) => {
+      setTimeout(() => {
+        resolve(Object.assign({}, params, { context: msg['context'] }));
+      }, 100);
+    });
+  },
+}), httpServerWithDelay);
 
 describe('Client', function() {
 
@@ -243,26 +252,25 @@ describe('Client', function() {
 
   it('should throw an error when the susbcription times out', function(done) {
     // hopefully 1ms is fast enough to time out before the server responds
-    const client = new Client(`ws://localhost:${TEST_PORT}/`, { timeout: 1 });
+    const client = new Client(`ws://localhost:${DELAYED_TEST_PORT}/`, { timeout: 1 });
 
     setTimeout( () => {
-    client.subscribe({
+      client.subscribe({
         query:
-        `subscription useInfo{
-          error
-        }`,
+          `subscription useInfo{
+            error
+          }`,
         operationName: 'useInfo',
         variables: {},
-        }, function(error, result) {
-          if (error) {
-            expect(error[0].message).to.equals('Subscription timed out - no response from server');
-            done();
-          }
-          if (result) {
-            assert(false);
-          }
+      }, function(error, result) {
+        if (error) {
+          expect(error[0].message).to.equals('Subscription timed out - no response from server');
+          done();
         }
-      );
+        if (result) {
+          assert(false);
+        }
+      });
     }, 100);
   });
 });
@@ -555,7 +563,7 @@ describe('Server', function() {
   });
 
   it('sends a keep alive signal in the socket', function(done) {
-    let client = new W3CWebSocket(`ws://localhost:${TEST_PORT + 1}/`, GRAPHQL_SUBSCRIPTIONS);
+    let client = new W3CWebSocket(`ws://localhost:${KEEP_ALIVE_TEST_PORT}/`, GRAPHQL_SUBSCRIPTIONS);
     let yieldCount = 0;
     client.onmessage = (message: any) => {
       const parsedMessage = JSON.parse(message.data);

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -7,3 +7,5 @@ declare module 'lodash.isstring' {
   import {isString} from 'lodash';
   export = isString;
 }
+
+declare module 'backo2';


### PR DESCRIPTION
This is an initial approach to handling having the client reconnect and resubscribe after losing its connection to the server. To enable this behavior a new `reconnect: true` option must be passed in to the constructor. Fixes #4 .