### PR TITLE
Don't throw in the server on certain unsub messages

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -95,7 +95,7 @@ class Server {
         }, keepAlive);
       }
 
-      const connectionSubscriptions: ConnectionSubscriptions = {};
+      const connectionSubscriptions: ConnectionSubscriptions = Object.create(null);
       connection.on('message', this.onMessage(connection, connectionSubscriptions, request));
       connection.on('close', this.onClose(connection, connectionSubscriptions));
     });

--- a/src/test/tests.ts
+++ b/src/test/tests.ts
@@ -18,6 +18,7 @@ import {
   SUBSCRIPTION_FAIL,
   SUBSCRIPTION_DATA,
   SUBSCRIPTION_KEEPALIVE,
+  SUBSCRIPTION_END,
 } from '../messageTypes';
 
 import {
@@ -722,6 +723,19 @@ describe('Server', function() {
     };
     client.onopen = () => {
       client.send(JSON.stringify({}));
+    };
+  });
+
+  it('does not crash on unsub for Object.prototype member', function(done) {
+    // Use websocket because Client.unsubscribe will only take a number.
+    const client = new W3CWebSocket(`ws://localhost:${TEST_PORT}/`,
+                                    GRAPHQL_SUBSCRIPTIONS);
+    client.onopen = () => {
+      client.send(JSON.stringify({type: SUBSCRIPTION_END, id: 'toString'}));
+      // Strangely we don't send any acknowledgement for unsubbing from an
+      // unknown sub, so we just set a timeout and implicitly assert that
+      // there's no uncaught exception within the server code.
+      setTimeout(done, 10);
     };
   });
 


### PR DESCRIPTION
To use an object as a map with arbitrary keys, you should either use
`Object.create(null)` or the `Map` class.  Otherwise you can run into trouble
where keys like `toString` and `constructor` are in your app too.  If the server
received such a message, an exception would get thrown within
SubscriptionManager.unsubscribe.

Noticed while reviewing @Urigo 's PR